### PR TITLE
fix: image-factory compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,8 @@ jobs:
           username: ${{ github.repository_owner }}
       - name: Push to registry
         if: github.event_name != 'pull_request'
+        env:
+          USERNAME: ${{ github.repository_owner }}
         run: |
           make  PUSH=true 
       - name: Retrieve PR labels
@@ -79,6 +81,7 @@ jobs:
       - name: extensions
         if: github.event_name != 'pull_request'
         env:
+          USERNAME: ${{ github.repository_owner }}
           PUSH: "true"
         run: |
           curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.18.0/go-containerregistry_Linux_x86_64.tar.gz" > go-containerregistry.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           USERNAME: ${{ github.repository_owner }}
+          CI_ARGS: --provenance=true
         run: |
           make  PUSH=true 
       - name: Retrieve PR labels

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,8 @@ jobs:
         env:
           PUSH: "true"
         run: |
+          curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.18.0/go-containerregistry_Linux_x86_64.tar.gz" > go-containerregistry.tar.gz
+          tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
           make extensions
       - name: release-notes
         if: startsWith(github.ref, 'refs/tags/')

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ internal/extensions/descriptions.yaml: internal/extensions/image-digests
 	@echo "Generating image descriptions..."
 	@echo -n "" > internal/extensions/descriptions.yaml
 	@for image in $(shell cat internal/extensions/image-digests); do \
-	  crane export $$image - | tar x -O --occurrence=1 manifest.yaml | yq -r ". += {\"$$image\": {\"author\": .metadata.author, \"description\": .metadata.description}} | del(.metadata, .version)" - >> internal/extensions/descriptions.yaml; \
+	  crane export $$image --platform linux/arm64 - | tar x -O --occurrence=1 manifest.yaml | yq -r ". += {\"$$image\": {\"author\": .metadata.author, \"description\": .metadata.description}} | del(.metadata, .version)" - >> internal/extensions/descriptions.yaml; \
 	done
 
 .PHONY: sign-images


### PR DESCRIPTION
The extensions manifest file contains tags without digests (eg `ghcr.io/nberlee/rk3588:v1.6.2@`) because crane is failing in CI. It appears to be preinstalled on upstream's selfhosted runners, but not the runners used here, so I've installed it manually.

[imager depends on multi-platform image manifests](https://github.com/siderolabs/talos/blob/e0dfbb8fba3c50652d0ecbae1db0b0660d0766a6/pkg/imager/profile/input.go#L257) so I've set `PLATFORM` and added qemu. It's not ideal though and might be worth fixing upstream at some point. I also set `USERNAME` in a few places so I could [test these changes](https://github.com/pl4nty/extensions/actions/runs/7667173975/job/20896470196) on a fork.